### PR TITLE
refactor(scss): rename mixins

### DIFF
--- a/src/components/gds-button/_index.scss
+++ b/src/components/gds-button/_index.scss
@@ -37,13 +37,13 @@
   }
 }
 
-@mixin button-s {
+@mixin size-s {
   height: 48px;
   font-size: 16px;
   letter-spacing: 1.6px;
 }
 
-@mixin button-m {
+@mixin size-m {
   height: 56px;
   font-size: 20px;
   letter-spacing: 1.28px;

--- a/src/components/gds-button/gds-button.scss
+++ b/src/components/gds-button/gds-button.scss
@@ -12,9 +12,9 @@
 }
 
 .gds-button-s {
-  @include button-s;
+  @include size-s;
 }
 
 .gds-button-m {
-  @include button-m;
+  @include size-m;
 }

--- a/src/components/gds-heading/_index.scss
+++ b/src/components/gds-heading/_index.scss
@@ -6,35 +6,35 @@
 }
 
 // H1
-@mixin heading-xxl {
+@mixin size-xxl {
   @include base;
   font-size: 72px;
   line-height: 74px;
 }
 
 // H2
-@mixin heading-xl {
+@mixin size-xl {
   @include base;
   font-size: 60px;
   line-height: 60px;
 }
 
 // H3
-@mixin heading-l {
+@mixin size-l {
   @include base;
   font-size: 36px;
   line-height: 36px;
 }
 
 // H4
-@mixin heading-m {
+@mixin size-m {
   @include base;
   font-size: 28px;
   line-height: 28px;
 }
 
 // H5
-@mixin heading-s {
+@mixin size-s {
   @include base;
   font-size: 20px;
   line-height: 24px;

--- a/src/components/gds-heading/gds-heading.scss
+++ b/src/components/gds-heading/gds-heading.scss
@@ -1,21 +1,21 @@
 @use "_index" as *;
 
 .gds-heading-xxl {
-  @include heading-xxl;
+  @include size-xxl;
 }
 
 .gds-heading-xl {
-  @include heading-xl;
+  @include size-xl;
 }
 
 .gds-heading-l {
-  @include heading-l;
+  @include size-l;
 }
 
 .gds-heading-m {
-  @include heading-m;
+  @include size-m;
 }
 
 .gds-heading-s {
-  @include heading-s;
+  @include size-s;
 }

--- a/src/components/gds-heading/index.scss
+++ b/src/components/gds-heading/index.scss
@@ -6,35 +6,35 @@
 }
 
 // H1
-@mixin heading-xxl {
+@mixin size-xxl {
   @include base;
   font-size: 72px;
   line-height: 74px;
 }
 
 // H2
-@mixin heading-xl {
+@mixin size-xl {
   @include base;
   font-size: 60px;
   line-height: 60px;
 }
 
 // H3
-@mixin heading-l {
+@mixin size-l {
   @include base;
   font-size: 36px;
   line-height: 36px;
 }
 
 // H4
-@mixin heading-m {
+@mixin size-m {
   @include base;
   font-size: 28px;
   line-height: 28px;
 }
 
 // H5
-@mixin heading-s {
+@mixin size-s {
   @include base;
   font-size: 20px;
   line-height: 24px;

--- a/src/components/gds-paragraph/_index.scss
+++ b/src/components/gds-paragraph/_index.scss
@@ -5,19 +5,19 @@
   letter-spacing: 0px;
 }
 
-@mixin paragraph-l {
+@mixin size-l {
   @include base;
   font-size: 20px;
   line-height: 24px;
 }
 
-@mixin paragraph-m {
+@mixin size-m {
   @include base;
   font-size: 17px;
   line-height: 27px;
 }
 
-@mixin paragraph-s {
+@mixin size-s {
   @include base;
   font-size: 15px;
   line-height: 25px;

--- a/src/components/gds-paragraph/gds-paragraph.scss
+++ b/src/components/gds-paragraph/gds-paragraph.scss
@@ -2,15 +2,15 @@
 
 .gds-paragraph-l {
   display: block;
-  @include paragraph-l;
+  @include size-l;
 }
 
 .gds-paragraph-m {
   display: block;
-  @include paragraph-m;
+  @include size-m;
 }
 
 .gds-paragraph-s {
   display: block;
-  @include paragraph-s;
+  @include size-s;
 }


### PR DESCRIPTION
these new names make more sense in a namespaced context fix #25

this is technically a breaking change if you use the mixins in a project. but i don't feel it's worth going from 0.x.x to 1.x.x over it, but if you think it should bump major version then I'm fine with that too
