### PR TITLE
feat: add color and spacing variables

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,4 @@
+const path = require('path');
 
 module.exports = {
   stories: ['../src/**/*.stories.js'],
@@ -8,30 +9,12 @@ module.exports = {
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.
 
-    config.module.rules.map((rule) => {
-      if (rule.oneOf) {
-        rule.oneOf = rule.oneOf.slice().map((subRule) => {
-          if (subRule.test instanceof RegExp && subRule.test.test('.scss')) {
-            return {
-              ...subRule,
-              use: [
-                ...subRule.use,
-                {
-                  loader: require.resolve('sass-resources-loader'),
-                  options: {
-                    resources: [
-                      path.resolve(__dirname, '../src/styles/index.scss')
-                    ]
-                  }
-                }
-              ],
-            }
-          }
-          return subRule;
-        });
-      }
-      return rule;
-    });
+    config.module.rules.push({
+      test: /\.scss$/,
+      use: ['style-loader', 'css-loader', 'sass-loader'],
+      include: path.resolve(__dirname, '../')
+    })
+
     return config;
   },
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,5 @@
 /* global window */
 
-// NOTE: Use plain css for now. Switch to using Sass once someone get's it to load in storybook preview iframe.
 import '../src/styles/index.css'
 
 import { defineCustomElements } from "../dist/esm/loader.mjs"

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,13 +6,24 @@
 
 :root {
   /* Colors */
-  --color-primary: #00a06e;
-  --color-secondary: #00a3b7;
+  --color-primary: var(--gds-color-ui-03);
+  --color-secondary: var(--gds-color-ui-04);
   --border-color-light: #dddddd;
-  --background-color-primary: #eeeeee;
-  --background-color-secondary: #eeeeee;
-  --text-color-primary: #333031;
-  /* TODO: all colors here and use them in the color definitions in this file. */
+  --background-color-primary: var(--gds-color-ui-background-01);
+  --background-color-secondary: var(--gds-color-ui-background-02);
+  --text-color-primary: var(--gds-color-black);
+
+  --gds-color-white: #ffffff;
+  --gds-color-black: #333031;
+  --gds-color-ui-background-01: #eeeeee;
+  --gds-color-ui-background-02: rgba(238, 238, 238, 0.75);
+  --gds-color-ui-01: #acacac;
+  --gds-color-ui-02: #646464;
+  --gds-color-ui-03: #00a06e;
+  --gds-color-ui-04: #00a3b7;
+  --gds-color-ui-05: #f1615e;
+  --gds-color-ui-06: #ffdcdd;
+  --gds-color-ui-07: #9185db;
 
   /* Spacing */
   --spacing-xxxs: 4px;
@@ -67,8 +78,8 @@
   /* Buttons */
   --button-font-family: Gilroy, Arial, Helvetica, sans-serif;
   --button-color: white;
-  --button-background-color: #333031;
-  --button-background-color-hover: #646464;
+  --button-background-color: var(--gds-color-black);
+  --button-background-color-hover: var(--gds-color-ui-02);
   --button-background-image: none;
   --button-background-image-hover: var(--button-background-image, none);
   --button-font-weight: 500;

--- a/src/styles/style.stories.js
+++ b/src/styles/style.stories.js
@@ -9,7 +9,22 @@ const style = `
   padding: 20px;
   margin: 20px;
   color: white;
+  text-shadow: 2px 2px black, 0 0 4px black;
 `
+
+const COLORS = [
+  'white',
+  'black',
+  'ui-background-01',
+  'ui-background-02',
+  'ui-01',
+  'ui-02',
+  'ui-03',
+  'ui-04',
+  'ui-05',
+  'ui-06',
+  'ui-07',
+]
 
 // prettier-ignore
 export const Colors = () => html`
@@ -20,8 +35,13 @@ export const Colors = () => html`
     <gds-card style="background-color: var(--color-secondary); ${style}">
       Secondary
     </gds-card>
-    <gds-card style="background-color: var(--body-background-color); ${style} color: black;">
+    <gds-card style="background-color: var(--body-background-color); ${style}">
       Body
     </gds-card>
+    ${COLORS.map(color => html`
+      <gds-card style="background-color: var(--gds-color-${color}); ${style}">
+        ${color}
+      </gds-card>
+    `)}
   </gds-paragraph>
 `


### PR DESCRIPTION
Added `variables.scss` to contain reusable sass variables, currently for colors and spacing.

Added `index.scss` which is mostly identical to `index.css` but uses sass variables instead.

Storybook and Stencil now import `index.scss` instead of `index.css`.