### PR TITLE
feat(logo-grid): support customizing the grid through variables

### DIFF
--- a/src/components/gds-logo-grid-item/_index.scss
+++ b/src/components/gds-logo-grid-item/_index.scss
@@ -1,2 +1,32 @@
 @mixin base {
+  display: block; /* by default, custom elements are display: inline */
+  contain: content; /* CSS containment FTW. */
+  padding: var(--logo-grid-item-padding);
+}
+
+@mixin container {
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    padding-top: 100%;
+    width: 100%;
+  }
+
+  > * {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+@mixin image {
+  width: 100%;
+  height: 100%;
+
+  object-fit: contain;
+  object-position: 50% 50%;
 }

--- a/src/components/gds-logo-grid-item/gds-logo-grid-item.scss
+++ b/src/components/gds-logo-grid-item/gds-logo-grid-item.scss
@@ -1,32 +1,15 @@
-// TODO: Move styles to _index.css if needed for WP?
-@use "index";
+@use "index" as *;
 
 :host {
-  display: block; /* by default, custom elements are display: inline */
-  contain: content; /* CSS containment FTW. */
-}
-
-.image {
-  display: block;
-  position: relative;
-  width: 100%;
-  height: 100%;
+  @include base;
 }
 
 img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  object-position: 50% 50%;
+  @include image;
 }
 
-a {
-  width: 100%;
-  height: 100%;
-}
+figure {
+  margin: 0;
 
-.gds-logo-grid-item-container {
-  width: 70%;
-  height: 70%;
-  padding: 15%;
+  @include container;
 }

--- a/src/components/gds-logo-grid-item/gds-logo-grid-item.tsx
+++ b/src/components/gds-logo-grid-item/gds-logo-grid-item.tsx
@@ -26,12 +26,12 @@ export class GdsLogoGridItem {
   render() {
     // Main content
     const content = (
-      <div class="gds-logo-grid-item-container">
-        <picture class="image">
+      <figure>
+        <picture>
           <source srcSet={this.imageUrl} />
           <img src={this.imageUrl} />
         </picture>
-      </div>
+      </figure>
     )
 
     // Render without a link

--- a/src/components/gds-logo-grid/_index.scss
+++ b/src/components/gds-logo-grid/_index.scss
@@ -1,2 +1,29 @@
+@use "../../styles/breakpoints" as *;
+
 @mixin base {
+  --logo-grid-item-count: var(--logo-grid-item-mobile-count);
+  --logo-grid-item-size: var(--logo-grid-item-mobile-size);
+
+  @include tabletOnly {
+    --logo-grid-item-count: var(--logo-grid-item-tablet-count);
+    --logo-grid-item-size: var(--logo-grid-item-tablet-size);
+  }
+
+  @include desktopOnly {
+    --logo-grid-item-count: var(--logo-grid-item-desktop-count);
+    --logo-grid-item-size: var(--logo-grid-item-desktop-size);
+  }
+
+  display: grid;
+  grid-template-columns: repeat(var(--logo-grid-item-count), minmax(auto, var(--logo-grid-item-size)));
+  grid-gap: 0;
+  max-width: calc(var(--logo-grid-item-size) * var(--logo-grid-item-count));
+  overflow: hidden;
+}
+
+@mixin item {
+  border-bottom: 1px solid var(--logo-grid-item-border-color);
+  border-right: 1px solid var(--logo-grid-item-border-color);
+  margin-right: -1px;
+  margin-bottom: -1px;
 }

--- a/src/components/gds-logo-grid/gds-logo-grid.scss
+++ b/src/components/gds-logo-grid/gds-logo-grid.scss
@@ -1,62 +1,9 @@
-// TODO: Move styles to _index.css if needed for WP?
 @use "index" as *;
-@use "../../styles/breakpoints" as *;
-
-$grid-item-desktop-size: 263px;
-$grid-item-mobile-size: 180px;
 
 :host {
   @include base;
-
-  display: grid;
-  grid-template-columns: repeat(auto-fit, $grid-item-desktop-size);
-  grid-template-rows: repeat(auto-fill, $grid-item-desktop-size);
-  grid-gap: 0;
-  justify-content: center;
-  max-width: 1060px;
 }
 
 ::slotted(gds-logo-grid-item) {
-  border-top: 1px solid black;
-  border-top: 1px solid var(--border-color-light);
-  border-left: 1px solid var(--border-color-light);
-}
-
-// Mobile has 2 columns
-// TODO: Use breakpoints
-@include mobileAndTablet {
-  :host {
-    grid-template-columns: repeat(auto-fit, $grid-item-mobile-size);
-    grid-template-rows: repeat(auto-fill, $grid-item-mobile-size);
-  }
-
-  // Remove top borders
-  ::slotted(:first-child),
-  ::slotted(:nth-child(2)) {
-    border-top: none;
-  }
-
-  // Remove borders on the left
-  ::slotted(:first-child),
-  ::slotted(:nth-child(2n + 1)) {
-    border-left: none;
-  }
-}
-
-// Desktop has 4 columns
-// TODO: Use breakpoints
-@include desktopOnly {
-  // Remove top borders
-  ::slotted(:first-child),
-  ::slotted(:nth-child(2)),
-  ::slotted(:nth-child(3)),
-  ::slotted(:nth-child(4)) {
-    border-top: none;
-  }
-
-  // Remove borders on the left
-  ::slotted(:first-child),
-  ::slotted(:nth-child(4n + 1)) {
-    border-left: none;
-  }
+  @include item;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -132,4 +132,14 @@
   /* Media Card */
   --media-card-media-height: 300px;
   --media-card-object-fit: cover;
+
+  /* Logo Grid */
+  --logo-grid-item-desktop-count: 4;
+  --logo-grid-item-tablet-count: 2;
+  --logo-grid-item-mobile-count: 2;
+  --logo-grid-item-desktop-size: 263px;
+  --logo-grid-item-tablet-size: 180px;
+  --logo-grid-item-mobile-size: 180px;
+  --logo-grid-item-border-color: var(--border-color-light);
+  --logo-grid-item-padding: 15%;
 }


### PR DESCRIPTION
I hate this grid! :D Insanely complicated to create an internal border!

1. What was used before is currently a bit broken and you can see it in [the current storybook](https://generoi.github.io/genero-design-system/?path=/story/containers--logo-grid).

<img width="614" alt="Screen Shot 2020-08-25 at 14 21 09" src="https://user-images.githubusercontent.com/302736/91206898-4ac87200-e6de-11ea-9b34-2ba438b2ffee.png">

I was planning to fix it by using [nth-last-child selector together with ~ selector](https://stackoverflow.com/a/12693500) but apparently you cannot use ~ with ::slotted. Only [compound selectors](https://www.w3.org/TR/selectors-4/#compound) and no combinators are allowed.

Before I reached that conclusion I also learned that sass doesnt support & selector within `::slotted()` (makes sense). There's a [proposal being worked on](https://github.com/sass/sass/pull/2861) for it and meanwhile material design does stuff [like this](https://github.com/material-components/material-components-web/commit/0a2e7fc8976e6481c9225609d7ff5354362472fa).

2. Next consideration was `grid-gap: 1px`, where we could set a background color on the grid, and then override it on the cells. Doesn't work since empty cells will have the background color of the grid. We could fix it in the Stencil component but not in WP.

3. Next up, I thought about adding an absolute positioned ::after element over the entire grid with `touch-events: none` that would have a border that overlaps the external border of the items. But there's no way of automatically setting the correct border-color of this pseudo element to match the background color. This could still be a valid solution if we cant hide the overflow. In WP it would work since we set `--block-background` when a block changes the background color, but it's sort of nasty.

4. Finally I settled with negative margins and `overflow: hidden`. Downside is that future variations eg hover styles cant overflow. Also due to using this approach we cannot use auto-fill columns since the width of the grid container wouldnt be known, and easily become larger than the grid, thus showing the border. This is fine I think and also applies to the previous solution.

Oh and I used `minmax` for the grid column sizes so that if it does need to scale down, it will. Previously it was overflowing the viewport on small screens.

WP implementation using Gallery block is:

```scss
@use '~genero-design-system/src/components/gds-logo-grid' as grid;
@use '~genero-design-system/src/components/gds-logo-grid-item' as item;

.wp-block-gallery.is-style-logo-grid {
  .blocks-gallery-grid {
    @include grid.base;

    margin-left: auto;
    margin-right: auto;
  }

  @include mq($from: medium) {
    @for $i from 1 through 8 {
      &.columns-#{$i} .blocks-gallery-grid {
        --logo-grid-item-count: #{$i};
      }
    }
  }

  .blocks-gallery-item {
    @include item.base;

    // Increase specificity to override Gutenberg selector
    // Sass needs `&&&` like styled components have.
    &.blocks-gallery-item.blocks-gallery-item {
      @include grid.item;
    }

    width: auto; // override Gutenberg

    figure {
      @include item.container;
    }

    img {
      @include item.image;
    }
  }
}

```

Let's hope we eventually get https://github.com/w3c/csswg-drafts/issues/2748 