### PR TITLE
feat(gds-media-card): support overlay color and blur effect

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -90,6 +90,14 @@ export namespace Components {
           * Image url.
          */
         "imageUrl": string;
+        /**
+          * Overlay.
+         */
+        "overlay": boolean;
+        /**
+          * Overlay effect.
+         */
+        "overlayEffect": string;
         "superimposedBottom": string;
         "superimposedLeft": string;
         "superimposedRight": string;
@@ -325,6 +333,14 @@ declare namespace LocalJSX {
           * Image url.
          */
         "imageUrl"?: string;
+        /**
+          * Overlay.
+         */
+        "overlay"?: boolean;
+        /**
+          * Overlay effect.
+         */
+        "overlayEffect"?: string;
         "superimposedBottom"?: string;
         "superimposedLeft"?: string;
         "superimposedRight"?: string;

--- a/src/components/gds-media-card/_index.scss
+++ b/src/components/gds-media-card/_index.scss
@@ -7,6 +7,8 @@
   position: relative;
   width: 100%;
   height: var(--media-card-media-height, 300px);
+  // Hide potential offset due to effects applied.
+  overflow: hidden;
 }
 
 @mixin image {
@@ -53,4 +55,22 @@
 
 @mixin content {
   padding: var(--spacing-m) var(--spacing-xs);
+}
+
+@mixin overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--media-card-overlay-color);
+  opacity: var(--media-card-overlay-opacity);
+  pointer-events: none;
+}
+
+@mixin image-blur-effect {
+  filter: blur(var(--media-card-blur-radius));
+  width: calc(100% + var(--media-card-blur-radius) * 2);
+  height: calc(var(--media-card-media-height, 300px) + var(--media-card-blur-radius) * 2);
+  margin: calc(var(--media-card-blur-radius) * -1);
 }

--- a/src/components/gds-media-card/gds-media-card.scss
+++ b/src/components/gds-media-card/gds-media-card.scss
@@ -10,6 +10,14 @@
 
 .image {
   @include image;
+
+  &.has-blur-effect {
+    @include image-blur-effect;
+  }
+}
+
+.overlay {
+  @include overlay;
 }
 
 .superimposed {

--- a/src/components/gds-media-card/gds-media-card.stories.js
+++ b/src/components/gds-media-card/gds-media-card.stories.js
@@ -47,8 +47,45 @@ export const MediaCard = () => html`
   <div style="margin: 40px;">
     <gds-media-card
       headline="Card Headline"
+      image-url="${getMockImageUrl('nature', 500, 500)}"
+      overlay-effect="blur"
+      description="This Media Card uses a paramenters for content and a blurred image"
+    >
+      <div slot="tags">
+        <gds-tag>From tags slot</gds-tag>
+        <gds-tag href="https://www.genero.fi">Tag with a link</gds-tag>
+      </div>
+    </gds-media-card>
+  </div>
+  <div style="margin: 40px;">
+    <gds-media-card
+      image-url="${getMockImageUrl('nature', 500, 500)}"
+      superimposed-url="images/superimpose.png"
+      superimposed-top="50"
+      superimposed-bottom="50"
+      overlay
+      overlay-effect="blur"
+      style="--media-card-overlay-color: var(--color-ui-03)"
+    >
+      <div slot="content">
+        <gds-link href="https://google.com">
+          <gds-heading size="s">This heading is a link</gds-heading>
+        </gds-link>
+        <gds-paragraph>
+          This Media Card uses a blurred overlay with a custom color
+        </gds-paragraph>
+        <gds-tag>First Tag</gds-tag>
+        <gds-tag href="https://www.genero.fi">Tag with a link</gds-tag>
+      </div>
+    </gds-media-card>
+  </div>
+  <div style="margin: 40px;">
+    <gds-media-card
+      headline="Card Headline"
       image-url="${getMockImageUrl('product', 500, 500)}"
-      description="This Media Card uses a paramenters for content."
+      overlay
+      style="--media-card-overlay-color: var(--color-ui-04)"
+      description="You can also apply only an overlay and keep the image sharp"
     >
       <div slot="tags">
         <gds-tag>From tags slot</gds-tag>

--- a/src/components/gds-media-card/gds-media-card.tsx
+++ b/src/components/gds-media-card/gds-media-card.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop } from '@stencil/core'
+import { Component, h, Prop, Watch } from '@stencil/core'
 
 /**
  * Media Card component.
@@ -39,9 +39,24 @@ export class GdsMediaCard {
   @Prop() superimposedLeft: string
   @Prop() superimposedRight: string
   /**
+   * Overlay.
+   */
+  @Prop() overlay: boolean
+  /**
+   * Overlay effect.
+   */
+  @Prop() overlayEffect: string
+  /**
    *
    */
   @Prop() description: string
+
+  @Watch('overlayEffect')
+  validateOverlayEffect(newValue: string) {
+    if (newValue && !['blur'].includes(newValue)) {
+      throw new Error('overlay-effect: invalid effect')
+    }
+  }
 
   render() {
     // Main card
@@ -52,7 +67,11 @@ export class GdsMediaCard {
           style={{
             marginBottom: this.superimposedBottom && `${this.superimposedBottom}px`,
           }}>
-          <img src={this.imageUrl} class="image" />
+          <img
+            src={this.imageUrl}
+            class={['image', this.overlayEffect ? `has-${this.overlayEffect}-effect` : ''].filter(Boolean).join(' ')}
+          />
+          {this.overlay && <div class="overlay" />}
         </div>
         <div class="content">
           {this.headline && (

--- a/src/components/gds-media-card/readme.md
+++ b/src/components/gds-media-card/readme.md
@@ -5,18 +5,20 @@
 
 ## Properties
 
-| Property             | Attribute             | Description                                          | Type     | Default     |
-| -------------------- | --------------------- | ---------------------------------------------------- | -------- | ----------- |
-| `description`        | `description`         |                                                      | `string` | `undefined` |
-| `headline`           | `headline`            | Title for the card (note: title is a reserved word). | `string` | `undefined` |
-| `href`               | `href`                | If defined, the card will be a link.                 | `string` | `undefined` |
-| `imageUrl`           | `image-url`           | Image url.                                           | `string` | `undefined` |
-| `superimposedBottom` | `superimposed-bottom` |                                                      | `string` | `undefined` |
-| `superimposedLeft`   | `superimposed-left`   |                                                      | `string` | `undefined` |
-| `superimposedRight`  | `superimposed-right`  |                                                      | `string` | `undefined` |
-| `superimposedTop`    | `superimposed-top`    | superimpose image overflow amount in pixels.         | `string` | `undefined` |
-| `superimposedUrl`    | `superimposed-url`    | superimpose image url.                               | `string` | `undefined` |
-| `target`             | `target`              | Link open target.                                    | `string` | `undefined` |
+| Property             | Attribute             | Description                                          | Type      | Default     |
+| -------------------- | --------------------- | ---------------------------------------------------- | --------- | ----------- |
+| `description`        | `description`         |                                                      | `string`  | `undefined` |
+| `headline`           | `headline`            | Title for the card (note: title is a reserved word). | `string`  | `undefined` |
+| `href`               | `href`                | If defined, the card will be a link.                 | `string`  | `undefined` |
+| `imageUrl`           | `image-url`           | Image url.                                           | `string`  | `undefined` |
+| `overlay`            | `overlay`             | Overlay.                                             | `boolean` | `undefined` |
+| `overlayEffect`      | `overlay-effect`      | Overlay effect.                                      | `string`  | `undefined` |
+| `superimposedBottom` | `superimposed-bottom` |                                                      | `string`  | `undefined` |
+| `superimposedLeft`   | `superimposed-left`   |                                                      | `string`  | `undefined` |
+| `superimposedRight`  | `superimposed-right`  |                                                      | `string`  | `undefined` |
+| `superimposedTop`    | `superimposed-top`    | superimpose image overflow amount in pixels.         | `string`  | `undefined` |
+| `superimposedUrl`    | `superimposed-url`    | superimpose image url.                               | `string`  | `undefined` |
+| `target`             | `target`              | Link open target.                                    | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -132,6 +132,9 @@
   /* Media Card */
   --media-card-media-height: 300px;
   --media-card-object-fit: cover;
+  --media-card-blur-radius: 5px;
+  --media-card-overlay-color: var(--color-white);
+  --media-card-overlay-opacity: 0.75;
 
   /* Logo Grid */
   --logo-grid-item-desktop-count: 4;


### PR DESCRIPTION
In hindsight, maybe we should abstract out the image into it's own component with these options, and then allow users to set it through a slot? Let me know what you think.

<img width="1383" alt="Screen Shot 2020-08-26 at 16 32 32" src="https://user-images.githubusercontent.com/302736/91348215-d8c55b00-e7b9-11ea-880d-b7bbfc309e26.png">
