### PR TITLE
Media card percentages

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -46,6 +46,9 @@ export namespace Components {
         "size": string;
     }
     interface GdsLink {
+        /**
+          * Block element.
+         */
         "block": boolean;
         /**
           * Link url.
@@ -318,6 +321,9 @@ declare namespace LocalJSX {
         "size"?: string;
     }
     interface GdsLink {
+        /**
+          * Block element.
+         */
         "block"?: boolean;
         /**
           * Link url.

--- a/src/components/gds-card/_index.scss
+++ b/src/components/gds-card/_index.scss
@@ -1,6 +1,5 @@
 @mixin card {
   box-sizing: border-box;
-  position: relative;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -10,6 +9,7 @@
   background-color: var(--card-background-color, white);
   box-shadow: var(--card-box-shadow);
   overflow: hidden;
+  width: 100vw;
   max-width: var(--card-width);
   flex-direction: column;
 }

--- a/src/components/gds-link/gds-link.scss
+++ b/src/components/gds-link/gds-link.scss
@@ -5,6 +5,7 @@ a {
   display: inline-block;
 }
 
-.block {
+:host-context([block]),
+:host-context([block] > a) {
   display: block;
 }

--- a/src/components/gds-link/gds-link.tsx
+++ b/src/components/gds-link/gds-link.tsx
@@ -5,6 +5,7 @@ import { Component, Prop, h } from '@stencil/core'
   styleUrl: 'gds-link.scss',
   // Use Light DOM so that Google bot can see important element without JS.
   shadow: false,
+  scoped: true,
 })
 export class GdsLink {
   /**
@@ -16,18 +17,13 @@ export class GdsLink {
    */
   @Prop() target: string
   /**
-   *
+   * Block element.
    */
-  @Prop() block: boolean
+  @Prop({ reflect: true }) block: boolean
 
   render() {
     return (
-      <a
-        class={{
-          block: this.block,
-        }}
-        href={this.href}
-        target={this.target}>
+      <a href={this.href} target={this.target}>
         <slot></slot>
       </a>
     )

--- a/src/components/gds-link/readme.md
+++ b/src/components/gds-link/readme.md
@@ -7,7 +7,7 @@
 
 | Property | Attribute | Description       | Type      | Default     |
 | -------- | --------- | ----------------- | --------- | ----------- |
-| `block`  | `block`   |                   | `boolean` | `undefined` |
+| `block`  | `block`   | Block element.    | `boolean` | `undefined` |
 | `href`   | `href`    | Link url.         | `string`  | `undefined` |
 | `target` | `target`  | Link open target. | `string`  | `undefined` |
 

--- a/src/components/gds-media-card/_index.scss
+++ b/src/components/gds-media-card/_index.scss
@@ -1,19 +1,24 @@
 @mixin media-card {
   position: relative;
-  display: inline-block; // @todo causes layout shift
+  display: inline-block;
+  max-width: 100%;
+  margin-top: max(0px, var(--superimposed-top));
 }
 
 @mixin media {
   position: relative;
   width: 100%;
-  height: var(--media-card-media-height, 300px);
+  height: 0;
+  padding-bottom: var(--media-card-media-height);
+  margin-bottom: max(0px, var(--superimposed-bottom));
   // Hide potential offset due to effects applied.
   overflow: hidden;
 }
 
 @mixin image {
+  position: absolute;
   width: 100%;
-  height: var(--media-card-media-height);
+  height: 100%;
 
   display: block;
   object-fit: var(--media-card-object-fit, cover);
@@ -21,16 +26,17 @@
 
 @mixin superimposed {
   width: 100%;
-  height: var(--media-card-media-height);
+  height: 0;
+  padding-bottom: var(--media-card-media-height);
   position: absolute;
   z-index: 1;
 
   & > .superimposed-image {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    top: calc(var(--superimposed-top, 0) * -1);
+    bottom: calc(var(--superimposed-bottom, 0) * -1);
+    left: calc(var(--superimposed-left, 0) * -1);
+    right: calc(var(--superimposed-right, 0) * -1);
 
     & > img {
       display: block;
@@ -71,8 +77,9 @@
 }
 
 @mixin image-blur-effect {
+  // until @stencil/sass 1.4.0 is released most likely
   filter: #{'opacity(var(--media-card-blur-opacity, 0.5))'} blur(var(--media-card-blur-radius));
   width: calc(100% + var(--media-card-blur-radius) * 2);
-  height: calc(var(--media-card-media-height, 300px) + var(--media-card-blur-radius) * 2);
+  height: calc(100% + var(--media-card-blur-radius) * 2);
   margin: calc(var(--media-card-blur-radius) * -1);
 }

--- a/src/components/gds-media-card/gds-media-card.scss
+++ b/src/components/gds-media-card/gds-media-card.scss
@@ -1,5 +1,9 @@
 @use "index" as *;
 
+:host {
+  display: block;
+}
+
 .media-card {
   @include media-card;
 }

--- a/src/components/gds-media-card/gds-media-card.tsx
+++ b/src/components/gds-media-card/gds-media-card.tsx
@@ -1,5 +1,7 @@
 import { Component, h, Prop, Watch } from '@stencil/core'
 
+const isNumeric = x => !isNaN(x) && isFinite(x)
+
 /**
  * Media Card component.
  *
@@ -59,20 +61,54 @@ export class GdsMediaCard {
   }
 
   render() {
+    const objectFitX =
+      isNumeric(this.superimposedLeft) && isNumeric(this.superimposedRight)
+        ? 'center'
+        : isNumeric(this.superimposedLeft)
+        ? 'left'
+        : isNumeric(this.superimposedRight)
+        ? 'right'
+        : 'center'
+
+    const objectFitY =
+      isNumeric(this.superimposedTop) && isNumeric(this.superimposedBottom)
+        ? 'center'
+        : isNumeric(this.superimposedTop)
+        ? 'top'
+        : isNumeric(this.superimposedBottom)
+        ? 'bottom'
+        : 'center'
+
+    // Optional superimposed image.
+    // Note: Superimpose needs to be outside of card because it has overflow hidden.
+    const superimposed = this.superimposedUrl && (
+      <div class="superimposed">
+        <div class="superimposed-image">
+          <img
+            src={this.superimposedUrl}
+            style={{
+              'object-position': `${objectFitY} ${objectFitX}`,
+            }}
+          />
+        </div>
+      </div>
+    )
+
     // Main card
     const card = (
       <gds-card>
+        {superimposed}
         <div
           class={{
             media: true,
             'has-overlay': this.overlay,
-          }}
-          style={{
-            marginBottom: this.superimposedBottom && `${this.superimposedBottom}px`,
           }}>
           <img
             src={this.imageUrl}
-            class={['image', this.overlayEffect ? `has-${this.overlayEffect}-effect` : ''].filter(Boolean).join(' ')}
+            class={{
+              image: true,
+              [`has-${this.overlayEffect}-effect`]: !!this.overlayEffect,
+            }}
           />
         </div>
         <div class="content">
@@ -99,56 +135,16 @@ export class GdsMediaCard {
       </gds-card>
     )
 
-    const isNumeric = x => !isNaN(x) && isFinite(x)
-
-    const objectFitX =
-      isNumeric(this.superimposedLeft) && isNumeric(this.superimposedRight)
-        ? 'center'
-        : isNumeric(this.superimposedLeft)
-        ? 'left'
-        : isNumeric(this.superimposedRight)
-        ? 'right'
-        : 'center'
-
-    const objectFitY =
-      isNumeric(this.superimposedTop) && isNumeric(this.superimposedBottom)
-        ? 'center'
-        : isNumeric(this.superimposedTop)
-        ? 'top'
-        : isNumeric(this.superimposedBottom)
-        ? 'bottom'
-        : 'center'
-
-    // Optional superimposed image.
-    // Note: Superimpose needs to be outside of card because it has overflow hidden.
-    const superimposed = this.superimposedUrl && (
-      <div class="superimposed">
-        <div
-          class="superimposed-image"
-          style={{
-            top: this.superimposedTop && `${this.superimposedTop * -1}px`,
-            bottom: this.superimposedBottom && `${this.superimposedBottom * -1}px`,
-            left: this.superimposedLeft && `${this.superimposedLeft * -1}px`,
-            right: this.superimposedRight && `${this.superimposedRight * -1}px`,
-          }}>
-          <img
-            src={this.superimposedUrl}
-            style={{
-              'object-position': `${objectFitY} ${objectFitX}`,
-            }}
-          />
-        </div>
-      </div>
-    )
-
-    // Container for card and superimpose image
+    // Container for card
     const mediaCard = (
       <div
         class="media-card"
         style={{
-          paddingTop: this.superimposedTop && `${this.superimposedTop}px`,
+          '--superimposed-top': this.superimposedTop ? `${this.superimposedTop}px` : '0px',
+          '--superimposed-bottom': this.superimposedBottom ? `${this.superimposedBottom}px` : '0px',
+          '--superimposed-left': this.superimposedLeft ? `${this.superimposedLeft}px` : '0px',
+          '--superimposed-right': this.superimposedRight ? `${this.superimposedRight}px` : '0px',
         }}>
-        {superimposed}
         {card}
       </div>
     )
@@ -158,7 +154,7 @@ export class GdsMediaCard {
 
     // Render with a link
     return (
-      <gds-link href={this.href} target={this.target}>
+      <gds-link href={this.href} target={this.target} block>
         {mediaCard}
       </gds-link>
     )


### PR DESCRIPTION
Support percentage media-card heights. This still doesn't work with percentage as offsets because there's no way to add the margin-top value with a percentage relative to the media (rather than the entire card). This still works pretty well for mobile.